### PR TITLE
[PATCH] alsa-oss: fix FTBFS with glibc v2.28

### DIFF
--- a/alsa/stdioemu.c
+++ b/alsa/stdioemu.c
@@ -37,7 +37,6 @@
 #endif
 
 #include <stdio.h>
-#include <libio.h>
 
 struct fd_cookie {
 	int fd;


### PR DESCRIPTION
In glibc upstream, libio/libio.h had been deprecated for applications and
became internal header in its v2.28 release. We can see below message in
its release note[1].

* The nonstandard header files <libio.h> and <_G_config.h> are no longer
  installed.  Software that was using either header should be updated to
  use standard <stdio.h> interfaces instead.

This brings FTBFS with glibc v2.28 due to missing <libio.h>. This commit
fixes it.

[1] https://www.sourceware.org/ml/libc-alpha/2018-08/msg00003.html

Reported-by: Adrian Bunk <bunk@debian.org>
Reference: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=916052
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>

```
---
 alsa/stdioemu.c | 1 -
 1 file changed, 1 deletion(-)
```