### PR TITLE
Include <sys/soundcard.h> instead of <linux/soundcard.h>

### DIFF
--- a/alsa/mixer.c
+++ b/alsa/mixer.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <assert.h>
-#include <linux/soundcard.h>
+#include <sys/soundcard.h>
 #include <alsa/asoundlib.h>
 
 #include "alsa-local.h"

--- a/alsa/pcm.c
+++ b/alsa/pcm.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <assert.h>
-#include <linux/soundcard.h>
+#include <sys/soundcard.h>
 #include <alsa/asoundlib.h>
 
 #include "alsa-local.h"

--- a/oss-redir/oss-redir.c
+++ b/oss-redir/oss-redir.c
@@ -32,7 +32,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include <errno.h>
-#include <linux/soundcard.h>
+#include <sys/soundcard.h>
 
 static int initialized = 0;
 static int native_oss = 1;


### PR DESCRIPTION
The `linux` folder strictly contains kernel headers, including OSSv3's.

A distribution may package the OSS development header(s) separately.